### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Adobe Firefly Python Client
 
+[![CI](https://github.com/msabramo/python-firefly/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/msabramo/python-firefly/actions/workflows/ci.yml)
+
 A Python client for the Adobe Firefly API,
 created using the [Adobe Firefly API Documentation].
 


### PR DESCRIPTION
Include a CI badge in the README to indicate the status of the continuous integration pipeline.